### PR TITLE
feat: switch base image to almalinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2-484
+FROM docker.io/almalinux/9-minimal:9.2-20230512
 
 LABEL maintainer="Radio Bern RaBe"
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The RaBe Universal Base Image 9 Minimal is a stripped down image that uses microdnf for package management.
 
-The image is based on the [Red Hat Universal Base Image 9 Minimal](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5)
-container provided by Red Hat.
+The image is based on the [AlmaLinux 9 UBI9 variant image](https://github.com/AlmaLinux/docker-images)
+container provided by AlmaLinux and based on the work from [Red Hat](https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d).
 
 ## Features
 
@@ -39,12 +39,10 @@ None yet.
 
 ## Advanced Usage
 
-If you need packages from EPEL (like `cowsay`) your have to download an `epel-release` package first:
+If you need packages from EPEL (like `cowsay`) your have to install an `epel-release` package first:
 
 ```Dockerfile
-RUN    curl -L -O https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-    && rpm -ivh ./epel-release-*.noarch.rpm \
-    && rm ./epel-release-*.noarch.rpm \
+RUN    microdnf install -y epel-release \
     && microdnf install -y \
          cowsay \
     && microdnf clean all


### PR DESCRIPTION
The main reason is to make like easier for downstream images when they need packages from epel (like ImageMagick, which has missing toolchain components in RHEL land) and just the out of the box availability of epel-release.

All in all i believe this will make downstream images more flexible and probably even more compatible with oss work at large while only really sacrificing the fact that we can't get this certified on RHEL (which isn't in any shape or way our target anyways).

It also looking like there won't be fewer vulnerability advisories using AlmaLinux, the main difference *should* be that their are more readily available for us to consume.