### PR TITLE
chore(ci): configure semantic releasing

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,12 +1,13 @@
-name: Run semantic-release
+name: Semantic Release
 
 on:
   push:
     branches:
       - main
+      - release/*
 
 jobs:
   semantic-release:
-    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@main
+    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@v0.20.7
     secrets:
       RABE_ITREAKTION_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}


### PR DESCRIPTION
# Initialize [go-semantic-release](https://go-semantic-release.xyz/).

Based on [radiorabe/actions: Semantic Release](https://github.com/radiorabe/actions#semantic-release).

Semantic Releases are done by [@it-reaktion](https://github.com/it-reaktion). Ensure that this repo has access to the org-level `RABE_ITREAKTION_GITHUB_TOKEN` secret before merging this.
