### PR TITLE
chore(ci): configure scheduled CI runs

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.20.6
+  schedule-trivy:
+    uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.20.7
     with:
-      image-ref: 'ghcr.io/radiorabe/ubi9-minimal:latest'
+      image-ref: ghcr.io/radiorabe/ubi9-minimal:latest


### PR DESCRIPTION
# Scheduled GitHub Actions

Configure scheduled CI runs.

## Schedule

```
13 12 * * *
```

## Jobs
* [Trivy](https://trivy.dev) (via [radiorabe/actions](https://radiorabe.github.io/actions/#container-schedule))
