### PR TITLE
chore: update ci/cd configuration

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -9,4 +9,4 @@ jobs:
   schedule-trivy:
     uses: radiorabe/actions/.github/workflows/schedule-trivy.yaml@v0.20.7
     with:
-      image-ref: ghcr.io/radiorabe/ubi9-minimal:latest
+      image-ref: 'ghcr.io/radiorabe/ubi9-minimal:latest'


### PR DESCRIPTION
# Initialize or Update CI/CD Pipelines

## Initialize [go-semantic-release](https://go-semantic-release.xyz/).

Based on [radiorabe/actions: Semantic Release](https://github.com/radiorabe/actions#semantic-release).

Semantic Releases are done by [@it-reaktion](https://github.com/it-reaktion). Ensure that this repo has access to the org-level `RABE_ITREAKTION_GITHUB_TOKEN` secret before merging this.

## Initialize Scheduled GitHub Actions

Configure scheduled CI runs.

### Schedule

```
13 12 * * *
```

### Jobs
* [Trivy](https://trivy.dev) (via [radiorabe/actions](https://radiorabe.github.io/actions/#container-schedule))

## Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
